### PR TITLE
route changes from api/<route> to just /<route>.

### DIFF
--- a/adviseme-api/app.js
+++ b/adviseme-api/app.js
@@ -41,7 +41,7 @@ app.use(require('express-session')({
 app.use('/users', auth);
 app.use('/notify', notification);
 
-//Use the API routes for all routes matching /api
+//Use the API routes in api.route.js
 app.use(api);
 
 // Angular DIST output folder

--- a/adviseme-api/app.js
+++ b/adviseme-api/app.js
@@ -42,7 +42,7 @@ app.use('/users', auth);
 app.use('/notify', notification);
 
 //Use the API routes for all routes matching /api
-app.use('/api', api);
+app.use(api);
 
 // Angular DIST output folder
 app.use(express.static('../adviseme-webapp/dist'));


### PR DESCRIPTION
route changes from api/<route> to just /<route>. Example: http://localhost:3000/classes instead of http://localhost:3000/api/classes 